### PR TITLE
Increase memory limit for CRD job

### DIFF
--- a/helm/crossplane/values.schema.json
+++ b/helm/crossplane/values.schema.json
@@ -69,6 +69,60 @@
                         }
                     }
                 },
+                "crossplane": {
+                    "type": "object",
+                    "properties": {
+                        "providers": {
+                            "type": "object",
+                            "properties": {
+                                "aws": {
+                                    "type": "object",
+                                    "properties": {
+                                        "version": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "azure": {
+                                    "type": "object",
+                                    "properties": {
+                                        "version": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "config": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ignoreCrossplaneConstraints": {
+                                            "type": "boolean"
+                                        },
+                                        "packagePullPolicy": {
+                                            "type": "string"
+                                        },
+                                        "revisionActivationPolicy": {
+                                            "type": "string"
+                                        },
+                                        "revisionHistoryLimit": {
+                                            "type": "integer"
+                                        },
+                                        "skipDependencyResolution": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                },
+                                "gcp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "version": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "images": {
                     "type": "object",
                     "properties": {
@@ -88,58 +142,13 @@
                         }
                     }
                 },
-                "providers": {
+                "kubernetes": {
                     "type": "object",
                     "properties": {
-                        "aws": {
+                        "provider": {
                             "type": "object",
                             "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "version": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "azure": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "version": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "config": {
-                            "type": "object",
-                            "properties": {
-                                "ignoreCrossplaneConstraints": {
-                                    "type": "boolean"
-                                },
-                                "packagePullPolicy": {
-                                    "type": "string"
-                                },
-                                "revisionActivationPolicy": {
-                                    "type": "string"
-                                },
-                                "revisionHistoryLimit": {
-                                    "type": "integer"
-                                },
-                                "skipDependencyResolution": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "gcp": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "version": {
+                                "kind": {
                                     "type": "string"
                                 }
                             }

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -34,7 +34,7 @@ giantswarm:
         memory: "64Mi"
         cpu: "250m"
       limits:
-        memory: "128Mi"
+        memory: "265Mi"
         cpu: "500m"
 
 replicas: 1


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23934
`crd-install` job is failing on install and upgrade due to `OOMKilled` status
on pods.

Example on upgrade:
```
  - lastTransitionTime: "2022-11-17T08:05:38Z"
    message: |-
      Helm upgrade failed: pre-upgrade hooks failed: job failed: BackoffLimitExceeded

      Last Helm logs:

      Add/Modify event for crossplane-crd-install-1-9-1: MODIFIED
      crossplane-crd-install-1-9-1: Jobs active: 1, jobs failed: 4, jobs succeeded: 0
      Add/Modify event for crossplane-crd-install-1-9-1: MODIFIED
      Starting delete for "crossplane-crd-install-1-9-1" Job
      warning: Upgrade "crossplane-crossplane" failed: pre-upgrade hooks failed: job failed: BackoffLimitExceeded
```