### PR TITLE
Add base for controller config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support controller configs and enable debug logging by default for all of them.
+
 ## [0.2.1] - 2022-11-17
 
 ### Fixed

--- a/helm/crossplane/templates/_helpers.tpl
+++ b/helm/crossplane/templates/_helpers.tpl
@@ -55,3 +55,15 @@ app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- define "controllerVolumeName" -}}
 {{- printf "%s-controller-%s-volume" (include "name" .) .volumeName -}}
 {{- end -}}
+
+{{- define "provider.aws.name" -}}
+{{- printf "provider-aws" -}}
+{{- end -}}
+
+{{- define "provider.azure.name" -}}
+{{- printf "provider-azure" -}}
+{{- end -}}
+
+{{- define "provider.gcp.name" -}}
+{{- printf "provider-gcp" -}}
+{{- end -}}

--- a/helm/crossplane/templates/provider-install/controller-config-aws.yaml
+++ b/helm/crossplane/templates/provider-install/controller-config-aws.yaml
@@ -5,7 +5,10 @@ metadata:
   name: "{{- include "provider.aws.name" . }}"
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  {{- with .Values.giantswarm.crossplane.providers.aws.controllerConfig }}
-    {{- . | toYaml | nindent 2 }}
+  {{- with .Values.giantswarm.crossplane.providers.aws.controllerConfig.args }}
+  args:
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
+  # This is also a guard statement for the case when all other options are unset
+  replicas: 1
 {{ end }}

--- a/helm/crossplane/templates/provider-install/controller-config-aws.yaml
+++ b/helm/crossplane/templates/provider-install/controller-config-aws.yaml
@@ -1,0 +1,11 @@
+{{ if eq .Values.giantswarm.kubernetes.provider.kind "aws" }}
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: "{{- include "provider.aws.name" . }}"
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  {{- with .Values.giantswarm.crossplane.providers.aws.controllerConfig }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}
+{{ end }}

--- a/helm/crossplane/templates/provider-install/controller-config-azure.yaml
+++ b/helm/crossplane/templates/provider-install/controller-config-azure.yaml
@@ -1,0 +1,11 @@
+{{ if eq .Values.giantswarm.kubernetes.provider.kind "azure" }}
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: "{{- include "provider.azure.name" . }}"
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  {{- with .Values.giantswarm.crossplane.providers.azure.controllerConfig }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}
+{{ end }}

--- a/helm/crossplane/templates/provider-install/controller-config-azure.yaml
+++ b/helm/crossplane/templates/provider-install/controller-config-azure.yaml
@@ -5,7 +5,10 @@ metadata:
   name: "{{- include "provider.azure.name" . }}"
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  {{- with .Values.giantswarm.crossplane.providers.azure.controllerConfig }}
-    {{- . | toYaml | nindent 2 }}
+  {{- with .Values.giantswarm.crossplane.providers.azure.controllerConfig.args }}
+  args:
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
+  # This is also a guard statement for the case when all other options are unset
+  replicas: 1
 {{ end }}

--- a/helm/crossplane/templates/provider-install/controller-config-gcp.yaml
+++ b/helm/crossplane/templates/provider-install/controller-config-gcp.yaml
@@ -5,7 +5,10 @@ metadata:
   name: "{{- include "provider.gcp.name" . }}"
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  {{- with .Values.giantswarm.crossplane.providers.gcp.controllerConfig }}
-    {{- . | toYaml | nindent 2 }}
+  {{- with .Values.giantswarm.crossplane.providers.gcp.controllerConfig.args }}
+  args:
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
+  # This is also a guard statement for the case when all other options are unset
+  replicas: 1
 {{ end }}

--- a/helm/crossplane/templates/provider-install/controller-config-gcp.yaml
+++ b/helm/crossplane/templates/provider-install/controller-config-gcp.yaml
@@ -1,0 +1,11 @@
+{{ if eq .Values.giantswarm.kubernetes.provider.kind "gcp" }}
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: "{{- include "provider.gcp.name" . }}"
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  {{- with .Values.giantswarm.crossplane.providers.gcp.controllerConfig }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}
+{{ end }}

--- a/helm/crossplane/templates/provider-install/provider-aws.yaml
+++ b/helm/crossplane/templates/provider-install/provider-aws.yaml
@@ -2,11 +2,13 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-aws
+  name: "{{- include "provider.aws.name" . }}"
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "labels.selector" . | nindent 4 }}
 spec:
+  controllerConfigRef:
+    name: "{{- include "provider.aws.name" . }}"
   ignoreCrossplaneConstraints: {{ .Values.giantswarm.crossplane.providers.config.ignoreCrossplaneConstraints }}
   package: "xpkg.upbound.io/crossplane-contrib/provider-aws:{{ .Values.giantswarm.crossplane.providers.aws.version }}"
   packagePullPolicy: {{ .Values.giantswarm.crossplane.providers.config.packagePullPolicy }}

--- a/helm/crossplane/templates/provider-install/provider-azure.yaml
+++ b/helm/crossplane/templates/provider-install/provider-azure.yaml
@@ -2,11 +2,13 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-azure
+  name: "{{- include "provider.azure.name" . }}"v
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "labels.selector" . | nindent 4 }}
 spec:
+  controllerConfigRef:
+    name: "{{- include "provider.azure.name" . }}"
   ignoreCrossplaneConstraints: {{ .Values.giantswarm.crossplane.providers.config.ignoreCrossplaneConstraints }}
   package: "xpkg.upbound.io/crossplane-contrib/provider-azure:{{ .Values.giantswarm.crossplane.providers.azure.version }}"
   packagePullPolicy: {{ .Values.giantswarm.crossplane.providers.config.packagePullPolicy }}

--- a/helm/crossplane/templates/provider-install/provider-gcp.yaml
+++ b/helm/crossplane/templates/provider-install/provider-gcp.yaml
@@ -2,11 +2,13 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-gcp
+  name: "{{- include "provider.gcp.name" . }}"
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "labels.selector" . | nindent 4 }}
 spec:
+  controllerConfigRef:
+    name: "{{- include "provider.gcp.name" . }}"
   ignoreCrossplaneConstraints: {{ .Values.giantswarm.crossplane.providers.config.ignoreCrossplaneConstraints }}
   package: "xpkg.upbound.io/crossplane-contrib/provider-gcp:{{ .Values.giantswarm.crossplane.providers.gcp.version }}"
   packagePullPolicy: {{ .Values.giantswarm.crossplane.providers.config.packagePullPolicy }}

--- a/helm/crossplane/values.schema.json
+++ b/helm/crossplane/values.schema.json
@@ -82,7 +82,10 @@
                                             "type": "object",
                                             "properties": {
                                                 "args": {
-                                                    "type": "array"
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
                                                 }
                                             }
                                         },
@@ -98,7 +101,10 @@
                                             "type": "object",
                                             "properties": {
                                                 "args": {
-                                                    "type": "array"
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
                                                 }
                                             }
                                         },
@@ -134,7 +140,10 @@
                                             "type": "object",
                                             "properties": {
                                                 "args": {
-                                                    "type": "array"
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
                                                 }
                                             }
                                         },

--- a/helm/crossplane/values.schema.json
+++ b/helm/crossplane/values.schema.json
@@ -78,6 +78,26 @@
                                 "aws": {
                                     "type": "object",
                                     "properties": {
+                                        "controllerConfig": {
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                                "args": {
+                                                    "type": "array"
+                                                },
+                                                "metadata": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "annotations": {
+                                                            "type": "object"
+                                                        },
+                                                        "labels": {
+                                                            "type": "object"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
                                         "version": {
                                             "type": "string"
                                         }
@@ -86,6 +106,26 @@
                                 "azure": {
                                     "type": "object",
                                     "properties": {
+                                        "controllerConfig": {
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                                "args": {
+                                                    "type": "array"
+                                                },
+                                                "metadata": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "annotations": {
+                                                            "type": "object"
+                                                        },
+                                                        "labels": {
+                                                            "type": "object"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
                                         "version": {
                                             "type": "string"
                                         }
@@ -114,6 +154,26 @@
                                 "gcp": {
                                     "type": "object",
                                     "properties": {
+                                        "controllerConfig": {
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                                "args": {
+                                                    "type": "array"
+                                                },
+                                                "metadata": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "annotations": {
+                                                            "type": "object"
+                                                        },
+                                                        "labels": {
+                                                            "type": "object"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
                                         "version": {
                                             "type": "string"
                                         }

--- a/helm/crossplane/values.schema.json
+++ b/helm/crossplane/values.schema.json
@@ -79,22 +79,10 @@
                                     "type": "object",
                                     "properties": {
                                         "controllerConfig": {
-                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                                 "args": {
                                                     "type": "array"
-                                                },
-                                                "metadata": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "annotations": {
-                                                            "type": "object"
-                                                        },
-                                                        "labels": {
-                                                            "type": "object"
-                                                        }
-                                                    }
                                                 }
                                             }
                                         },
@@ -107,22 +95,10 @@
                                     "type": "object",
                                     "properties": {
                                         "controllerConfig": {
-                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                                 "args": {
                                                     "type": "array"
-                                                },
-                                                "metadata": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "annotations": {
-                                                            "type": "object"
-                                                        },
-                                                        "labels": {
-                                                            "type": "object"
-                                                        }
-                                                    }
                                                 }
                                             }
                                         },
@@ -155,22 +131,10 @@
                                     "type": "object",
                                     "properties": {
                                         "controllerConfig": {
-                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                                 "args": {
                                                     "type": "array"
-                                                },
-                                                "metadata": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "annotations": {
-                                                            "type": "object"
-                                                        },
-                                                        "labels": {
-                                                            "type": "object"
-                                                        }
-                                                    }
                                                 }
                                             }
                                         },

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -22,25 +22,16 @@ giantswarm:
         version: v0.33.0
         controllerConfig:
           args: []
-          metadata:
-            annotations: {}
-            labels: {}
 
       azure:
         version: v0.20.1
         controllerConfig:
           args: []
-          metadata:
-            annotations: {}
-            labels: {}
 
       gcp:
         version: v0.22.0
         controllerConfig:
           args: []
-          metadata:
-            annotations: {}
-            labels: {}
 
   crds:
     install: true

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -21,26 +21,26 @@ giantswarm:
       aws:
         version: v0.33.0
         controllerConfig:
-          args: [ ]
+          args: []
           metadata:
-            annotations: { }
-            labels: { }
+            annotations: {}
+            labels: {}
 
       azure:
         version: v0.20.1
         controllerConfig:
-          args: [ ]
+          args: []
           metadata:
-            annotations: { }
-            labels: { }
+            annotations: {}
+            labels: {}
 
       gcp:
         version: v0.22.0
         controllerConfig:
-          args: [ ]
+          args: []
           metadata:
-            annotations: { }
-            labels: { }
+            annotations: {}
+            labels: {}
 
   crds:
     install: true

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -20,12 +20,27 @@ giantswarm:
 
       aws:
         version: v0.33.0
+        controllerConfig:
+          args: [ ]
+          metadata:
+            annotations: { }
+            labels: { }
 
       azure:
         version: v0.20.1
+        controllerConfig:
+          args: [ ]
+          metadata:
+            annotations: { }
+            labels: { }
 
       gcp:
         version: v0.22.0
+        controllerConfig:
+          args: [ ]
+          metadata:
+            annotations: { }
+            labels: { }
 
   crds:
     install: true

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -21,17 +21,20 @@ giantswarm:
       aws:
         version: v0.33.0
         controllerConfig:
-          args: []
+          args:
+            - -- debug
 
       azure:
         version: v0.20.1
         controllerConfig:
-          args: []
+          args:
+            - -- debug
 
       gcp:
         version: v0.22.0
         controllerConfig:
-          args: []
+          args:
+            - -- debug
 
   crds:
     install: true


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/24737

What I primarily try to solve here is to be able to enable debug logging for example for the AWS operator but controller configs are generally vey nice to have better control over the deployer provider operators.

I have one security concern with the implementation, which may not be valid cos the added counter measure + the fact that we manage it via Flux in the MCs. Please check my comment below.