### PR TITLE
add permissions to CNP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CilliumNetworkPolicy was forbidding crossplane controller to download provider packages on CAPI
+
 ## [0.4.2] - 2023-01-19
 
 ### Added

--- a/helm/crossplane/templates/cilium-network-policy.yaml
+++ b/helm/crossplane/templates/cilium-network-policy.yaml
@@ -14,5 +14,7 @@ spec:
   egress:
   - toEntities:
     - kube-apiserver
+    - cluster
+    - world
   endpointSelector: {}
 {{- end }}


### PR DESCRIPTION
Without these additional policies, crossplane controller can't
- access `coredns` (so `clsuter` added)
- download provider controller images (`world` added)