### PR TITLE
Pin back upbound/provider-aws to v0.20.0

### DIFF
--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -21,7 +21,7 @@ giantswarm:
         ignoreCrossplaneConstraints: false
         packagePullPolicy: IfNotPresent
         revisionActivationPolicy: Automatic
-        revisionHistoryLimit: 0
+        revisionHistoryLimit: 1
         skipDependencyResolution: false
 
       upboundAws:

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -25,7 +25,7 @@ giantswarm:
         skipDependencyResolution: false
 
       upboundAws:
-        version: v0.28.0
+        version: v0.20.0
         controllerConfig:
           args:
             - --debug


### PR DESCRIPTION
CRD count for v0.20.0 is 417 vs. v0.28.0 is 798