### PR TITLE
1.11 improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- disable leader election in default values since the default replica count is 1
+- add 'projected' volume to allowed ones in PSP
+
 ## [2.0.0] - 2023-02-27
 
 ### Removed

--- a/helm/crossplane/templates/psp.yaml
+++ b/helm/crossplane/templates/psp.yaml
@@ -32,6 +32,7 @@ spec:
     - 'secret'
     - 'configMap'
     - 'emptyDir'
+    - 'projected'
   allowPrivilegeEscalation: false
   hostNetwork: false
   hostIPC: false

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -41,7 +41,7 @@ customAnnotations: {}
 serviceAccount:
   customAnnotations: {}
 
-leaderElection: true
+leaderElection: false
 args:
   - --debug
 
@@ -63,7 +63,7 @@ rbacManager:
   skipAggregatedClusterRoles: false
   replicas: 1
   managementPolicy: All
-  leaderElection: true
+  leaderElection: false
   args: {}
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
- disable leader election in default values since the default replica count is 1
- add 'projected' volume to allowed ones in PSP