### PR TITLE
Add priorityClass

### DIFF
--- a/helm/crossplane/templates/priorityclass.yaml
+++ b/helm/crossplane/templates/priorityclass.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: crossplane-critical
+value: 600000000
+globalDefault: false
+description: "This priority class should be used for scheduling the crossplane provider only."


### PR DESCRIPTION
To accomadate environments that require extensive resources for the provider, this introduces a priorityClass `crossplane-critical`.

This can then be bound to the provider pod when required.

By default, this is unbound.