### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [2.4.0] - 2023-11-02
 
 ### Changed

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -1,6 +1,6 @@
 giantswarm:
   images:
-    registry: docker.io
+    registry: gsoci.azurecr.io
     crossplane:
       image: giantswarm/crossplane
     xfn:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
