### PR TITLE
Restrict CRD job's security context to comply with PSS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Restrict CRD job's security context to comply with PSS.
+- Change security context defaults to comply with PSS.
 
 ## [2.4.2] - 2024-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restrict CRD job's security context to comply with PSS.
+
 ## [2.4.2] - 2024-01-29
 
 ### Fixed

--- a/helm/crossplane/templates/crd-install/crd-job.yaml
+++ b/helm/crossplane/templates/crd-install/crd-job.yaml
@@ -23,6 +23,9 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 2000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
@@ -42,7 +45,11 @@ spec:
 
           kubectl apply -f /data/ 2>&1
         securityContext:
+          capabilities:
+            drop:
+              - ALL
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         volumeMounts:
 {{- range $path, $_ := .Files.Glob "crd-base/**" }}
         - name: {{ $path | base | trimSuffix ".yaml" }}

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -172,6 +172,9 @@ securityContextRBACManager:
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
+  capabilities:
+    drop:
+      - ALL
 
 metrics:
   # -- Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods.
@@ -189,10 +192,7 @@ extraEnvVarsRBACManager: {}
 podSecurityContextCrossplane: {}
 
 # -- Add a custom `securityContext` to the RBAC Manager pod.
-podSecurityContextRBACManager:
-  capabilities:
-    drop:
-      - ALL
+podSecurityContextRBACManager: {}
 
 # -- Add custom `volumes` to the Crossplane pod.
 extraVolumesCrossplane: {}

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -131,6 +131,9 @@ securityContextCrossplane:
   allowPrivilegeEscalation: false
   # -- Set the Crossplane pod root file system as read-only.
   readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 packageCache:
   # -- Set to `Memory` to hold the package cache in a RAM backed file system. Useful for Crossplane development.
@@ -163,6 +166,9 @@ securityContextRBACManager:
   allowPrivilegeEscalation: false
   # -- Set the RBAC Manager pod root file system as read-only.
   readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 metrics:
   # -- Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods.
@@ -177,10 +183,16 @@ extraEnvVarsCrossplane: {}
 extraEnvVarsRBACManager: {}
 
 # -- Add a custom `securityContext` to the Crossplane pod.
-podSecurityContextCrossplane: {}
+podSecurityContextCrossplane:
+  capabilities:
+    drop:
+      - ALL
 
 # -- Add a custom `securityContext` to the RBAC Manager pod.
-podSecurityContextRBACManager: {}
+podSecurityContextRBACManager:
+  capabilities:
+    drop:
+      - ALL
 
 # -- Add custom `volumes` to the Crossplane pod.
 extraVolumesCrossplane: {}

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -134,6 +134,9 @@ securityContextCrossplane:
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
+  capabilities:
+      drop:
+        - ALL
 
 packageCache:
   # -- Set to `Memory` to hold the package cache in a RAM backed file system. Useful for Crossplane development.
@@ -183,10 +186,7 @@ extraEnvVarsCrossplane: {}
 extraEnvVarsRBACManager: {}
 
 # -- Add a custom `securityContext` to the Crossplane pod.
-podSecurityContextCrossplane:
-  capabilities:
-    drop:
-      - ALL
+podSecurityContextCrossplane: {}
 
 # -- Add a custom `securityContext` to the RBAC Manager pod.
 podSecurityContextRBACManager:

--- a/helm/crossplane/values.yaml
+++ b/helm/crossplane/values.yaml
@@ -135,8 +135,8 @@ securityContextCrossplane:
   seccompProfile:
     type: RuntimeDefault
   capabilities:
-      drop:
-        - ALL
+    drop:
+      - ALL
 
 packageCache:
   # -- Set to `Memory` to hold the package cache in a RAM backed file system. Useful for Crossplane development.


### PR DESCRIPTION
These changes are needed to run crossplane on a 1.25 kubernetes cluster with PSS