### PR TITLE
Automated update to tag v1.15.2

### DIFF
--- a/ci-update-to-latest.sh
+++ b/ci-update-to-latest.sh
@@ -1,0 +1,1 @@
+../git-subtree-utils/ci-update-to-latest.sh

--- a/git-subtree-update.sh
+++ b/git-subtree-update.sh
@@ -1,0 +1,1 @@
+../git-subtree-utils/git-subtree-update.sh

--- a/subtree-cfg.ini
+++ b/subtree-cfg.ini
@@ -1,0 +1,11 @@
+[chart]
+REMOTE_URL=https://github.com/crossplane/crossplane.git
+REMOTE_DIR=cluster/charts
+DOWN_DIR=helm
+SQUASH=true
+
+[crds]
+REMOTE_URL=https://github.com/crossplane/crossplane.git
+REMOTE_DIR=cluster/crds
+DOWN_DIR=helm/crossplane/crd-base
+SQUASH=true


### PR DESCRIPTION
This PR updates the chart using git subtree to the latest tag in the upstream repository.